### PR TITLE
Support unparsed durations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /pkg/
 /spec/reports/
 /tmp/
+/vendor/
 
 # rspec failure tracking
 .rspec_status

--- a/lib/active_support/duration/human_string.rb
+++ b/lib/active_support/duration/human_string.rb
@@ -42,7 +42,7 @@ module ActiveSupport
     #
     def human_str(precision: nil, separator: '', delimiter: ' ', use_2_digit_numbers: false)
       HumanStringSerializer.new(
-        self,
+        self.class.build(value),
         precision: precision,
         separator: separator,
         delimiter: delimiter,

--- a/spec/active_support/duration_spec.rb
+++ b/spec/active_support/duration_spec.rb
@@ -1,41 +1,51 @@
+def durations(value)
+  [ActiveSupport::Duration.build(value), ActiveSupport::Duration.seconds(value)]
+end
+
 RSpec.describe ActiveSupport::Duration do
   describe '#human_str' do
     it do
-      duration = ActiveSupport::Duration.build(3500)
-      expect(duration.human_str                ).to eq '58m 20s'
-      expect(duration.human_str(delimiter: '') ).to eq '58m20s'
-      expect(duration.human_str(separator: ' ')).to eq '58 m 20 s'
-      expect(duration.human_str(delimiter: ', ', separator: ' ')).to eq '58 m, 20 s'
+      durations(3500).each do |duration|
+        expect(duration.human_str                ).to eq '58m 20s'
+        expect(duration.human_str(delimiter: '') ).to eq '58m20s'
+        expect(duration.human_str(separator: ' ')).to eq '58 m 20 s'
+        expect(duration.human_str(delimiter: ', ', separator: ' ')).to eq '58 m, 20 s'
+      end
     end
 
     it 'precision' do
-      duration = ActiveSupport::Duration.build(65.12345)
-      expect(duration.human_str              ).to eq '1m 5.12345s'
-      expect(duration.human_str(precision: 3)).to eq '1m 5.123s'
-      expect(duration.human_str(precision: 0)).to eq '1m 5s'
+      durations(65.12345).each do |duration|
+        expect(duration.human_str              ).to eq '1m 5.12345s'
+        expect(duration.human_str(precision: 3)).to eq '1m 5.123s'
+        expect(duration.human_str(precision: 0)).to eq '1m 5s'
+      end
     end
 
     it do
-      duration = ActiveSupport::Duration.build(35)
-      expect(duration.human_str).to eq '35s'
+      durations(35).each do |duration|
+        expect(duration.human_str).to eq '35s'
+      end
     end
 
     it 'use_2_digit_numbers: false' do
-      duration = ActiveSupport::Duration.build(65)
-      expect(duration.human_str).to eq '1m 5s'
+      durations(65).each do |duration|
+        expect(duration.human_str).to eq '1m 5s'
+      end
     end
 
     it 'use_2_digit_numbers: true' do
-      duration = ActiveSupport::Duration.build(65)
-      expect(duration.human_str(use_2_digit_numbers: true)).to eq '1m 05s'
+      durations(65).each do |duration|
+        expect(duration.human_str(use_2_digit_numbers: true)).to eq '1m 05s'
+      end
     end
   end
 
   describe '#human_string, #to_human_s aliases' do
     it do
-      duration = ActiveSupport::Duration.build(3500)
-      expect(duration.human_string).to eq duration.human_str
-      expect(duration.to_human_s  ).to eq duration.human_str
+      durations(3500).each do |duration|
+        expect(duration.human_string).to eq duration.human_str
+        expect(duration.to_human_s  ).to eq duration.human_str
+      end
     end
   end
 end


### PR DESCRIPTION
e.g. via `Numeric#seconds`, `Numeric#minutes` [etc.](https://edgeguides.rubyonrails.org/active_support_core_extensions.html#extensions-to-numeric-time)

```ruby
require 'active_support'
require 'active_support/core_ext/numeric/time'

ActiveSupport::Duration.build(12345).parts   # => {:hours=>3, :minutes=>25, :seconds=>45.0}
ActiveSupport::Duration.seconds(12345).parts # => {:seconds=>12345}
12345.seconds.parts                          # => {:seconds=>12345}
```

### before:

```ruby
12345.seconds.human_string # => "12345s"
```

### after:

```ruby
12345.seconds.human_string # => "3h 25m 45s"
```